### PR TITLE
Customized main tab header to put gradient as in design

### DIFF
--- a/src/components/navigation/MainStackNavigator.tsx
+++ b/src/components/navigation/MainStackNavigator.tsx
@@ -108,7 +108,10 @@ class RootNavigator extends React.Component<any, any> {
         <ProfileModalProvider navigation={this.props.navigation}>
           <MainStackNavigator
             navigation={this.props.navigation}
-            screenProps={{ theme: this.props.theme }}
+            screenProps={{
+              theme: this.props.screenProps.theme,
+              changeTheme: this.props.screenProps.changeTheme,
+            }}
           />
         </ProfileModalProvider>
       </View>

--- a/src/components/navigation/MainTabNavigator.tsx
+++ b/src/components/navigation/MainTabNavigator.tsx
@@ -1,5 +1,4 @@
 import {
-  Image,
   ImageStyle,
   StyleSheet,
   Text,
@@ -7,13 +6,19 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import {
+  MaterialTopTabBar as RNMaterialTopTabBar,
+  createMaterialTopTabNavigator,
+} from 'react-navigation-tabs';
 import { SvgNoProfile, SvgPlus } from '../../utils/Icons';
 
+import Constants from 'expo-constants';
 import Friend from '../screen/Friend';
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
 import Message from '../screen/Message';
 import React from 'react';
 import { ScreenProps } from './SwitchNavigator';
-import { createMaterialTopTabNavigator } from 'react-navigation-tabs';
 import { getString } from '../../../STRINGS';
 
 interface Styles {
@@ -22,79 +27,101 @@ interface Styles {
   txtSub: TextStyle;
 }
 
-const styles: Styles = StyleSheet.create({
-  imgHeaderLeft: {
-    marginLeft: 20,
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    borderColor: 'white',
-    borderWidth: 1,
-  },
-  txt: {
-    color: 'white',
-    fontSize: 15,
-  },
-  txtSub: {
-    color: 'white',
-    fontSize: 15,
-    fontWeight: '700',
-  },
-});
+const MaterialTopTabBar = (props: any) => {
+  const { theme } = props.screenProps;
+  return (
+    <RNMaterialTopTabBar
+      {...props}
+      activeTintColor={theme.indicatorColor}
+      inactiveTintColor={theme.tintColor}
+      indicatorStyle={{
+        backgroundColor: theme.indicatorColor,
+      }}
+      tabStyle={{
+        backgroundColor: 'transparent',
+      }}
+      style={{
+        backgroundColor: theme.background,
+      }}
+    />
+  );
+};
 
 const MainTabNavigator = createMaterialTopTabNavigator(
   {
-    Friend: { screen: Friend },
-    Message: { screen: Message },
+    Friend: {
+      screen: Friend,
+      navigationOptions: {
+        tabBarLabel: getString('FRIEND'),
+        tabBarAccessibilityLabel: getString('FRIEND'),
+      },
+    },
+    Message: {
+      screen: Message,
+      navigationOptions: {
+        tabBarLabel: getString('MESSAGE'),
+        tabBarAccessibilityLabel: getString('MESSAGE'),
+      },
+    },
   },
   {
-    // prettier-ignore
-    navigationOptions: ({ navigation }: { navigation: any }) => {
-      return {
-        tabBarVisible: true,
-        tabBarLabel: ({ focused }: { focused: boolean }) => {
-          const { routeName } = navigation.state;
-          switch (routeName) {
-          case 'Friend':
-            return function FriendTab() {
-              return (
-                <Text style={[styles.txt, { opacity: focused ? 1 : 0.8 }]}>
-                  {getString('FRIEND')} <Text style={styles.txtSub}>24</Text>
-                </Text>
-              );
-            };
-          case 'Message':
-            return function MessageTab() {
-              return (
-                <Text style={[styles.txt, { opacity: focused ? 1 : 0.8 }]}>
-                  {getString('MESSAGE')} <Text style={styles.txtSub}>8</Text>
-                </Text>
-              );
-            };
-          }
-          return null;
-        },
-      };
-    },
     animationEnabled: true,
     swipeEnabled: true,
-    tabBarOptions: {
-      indicatorStyle: {
-        backgroundColor: 'white',
-      },
-      style: {
-        height: 44,
-        justifyContent: 'center',
-        backgroundColor: 'rgb(58,139,255)',
-        borderTopColor: 'transparent',
-        borderTopWidth: 0,
-        elevation: 0,
-      },
-    },
+    tabBarComponent: MaterialTopTabBar,
   },
 );
 
 export default MainTabNavigator;
+
+const CustomHeader = (props: any) => {
+  const { theme } = props.screenProps;
+  return (
+    <LinearGradient
+      style={{
+        paddingTop: Constants.statusBarHeight,
+        height: 44 + Constants.statusBarHeight,
+        alignSelf: 'stretch',
+        alignItems: 'center',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+      }}
+      start={[0.4, 0.6]}
+      end={[1.0, 0.85]}
+      locations={[0, 0.85]}
+      colors={[theme.primary, theme.primaryLight]}
+    >
+      <View style={{ marginLeft: 8 }}>
+        <TouchableOpacity
+          style={{ padding: 8 }}
+          activeOpacity={0.5}
+          onPress={() => props.navigation.navigate('ProfileUpdate')}
+        >
+          <Ionicons name='ios-person' size={24} color={theme.background} />
+        </TouchableOpacity>
+      </View>
+      <View>
+        <Text
+          style={{
+            fontSize: 18,
+            fontWeight: '500',
+            color: theme.background,
+          }}
+        >
+          HackaTalk
+        </Text>
+      </View>
+      <View style={{ marginRight: 8 }}>
+        <TouchableOpacity
+          style={{ padding: 8 }}
+          activeOpacity={0.5}
+          onPress={() => props.navigation.navigate('SearchUser')}
+        >
+          <Ionicons name='ios-search' size={24} color={theme.background} />
+        </TouchableOpacity>
+      </View>
+    </LinearGradient>
+  );
+};
 
 export const MainTabNavigationOptions = ({
   navigation,
@@ -105,45 +132,6 @@ export const MainTabNavigationOptions = ({
 }) => {
   const { theme } = screenProps;
   return {
-    title: 'HackaTalk',
-    headerStyle: {
-      backgroundColor: theme.background,
-    },
-    headerTitleStyle: {
-      color: theme.fontColor,
-    },
-    headerLeft: (
-      <View
-        style={{
-          marginLeft: 16,
-        }}
-      >
-        <TouchableOpacity
-          activeOpacity={0.5}
-          onPress={() => navigation.navigate('ProfileUpdate')}
-        >
-          <SvgNoProfile
-            width={20}
-            style={{
-              color: theme.btnPrimary,
-            }}
-          />
-        </TouchableOpacity>
-      </View>
-    ),
-    headerRight: (
-      <View
-        style={{
-          marginRight: 16,
-        }}
-      >
-        <TouchableOpacity
-          activeOpacity={0.5}
-          onPress={() => navigation.navigate('SearchUser')}
-        >
-          <SvgPlus width={20} />
-        </TouchableOpacity>
-      </View>
-    ),
+    header: CustomHeader,
   };
 };

--- a/src/components/navigation/MainTabNavigator.tsx
+++ b/src/components/navigation/MainTabNavigator.tsx
@@ -7,6 +7,11 @@ import {
   View,
 } from 'react-native';
 import {
+  NavigationParams,
+  NavigationScreenProp,
+  NavigationState,
+} from 'react-navigation';
+import {
   MaterialTopTabBar as RNMaterialTopTabBar,
   createMaterialTopTabNavigator,
 } from 'react-navigation-tabs';
@@ -73,8 +78,13 @@ const MainTabNavigator = createMaterialTopTabNavigator(
 
 export default MainTabNavigator;
 
-const CustomHeader = (props: any) => {
-  const { theme } = props.screenProps;
+interface Props {
+  screenProps: ScreenProps;
+  navigation: NavigationScreenProp<NavigationState, NavigationParams>;
+}
+
+const CustomHeader = (props: Props) => {
+  const { theme, changeTheme } = props.screenProps;
   return (
     <LinearGradient
       style={{
@@ -96,27 +106,27 @@ const CustomHeader = (props: any) => {
           activeOpacity={0.5}
           onPress={() => props.navigation.navigate('ProfileUpdate')}
         >
-          <Ionicons name='ios-person' size={24} color={theme.background} />
+          <Ionicons name='ios-person' size={24} color='white' />
         </TouchableOpacity>
       </View>
-      <View>
+      <TouchableOpacity onPress={() => changeTheme()}>
         <Text
           style={{
             fontSize: 18,
             fontWeight: '500',
-            color: theme.background,
+            color: 'white',
           }}
         >
           HackaTalk
         </Text>
-      </View>
+      </TouchableOpacity>
       <View style={{ marginRight: 8 }}>
         <TouchableOpacity
           style={{ padding: 8 }}
           activeOpacity={0.5}
           onPress={() => props.navigation.navigate('SearchUser')}
         >
-          <Ionicons name='ios-search' size={24} color={theme.background} />
+          <Ionicons name='ios-search' size={24} color='white' />
         </TouchableOpacity>
       </View>
     </LinearGradient>
@@ -130,7 +140,6 @@ export const MainTabNavigationOptions = ({
   navigation: any;
   screenProps: ScreenProps;
 }) => {
-  const { theme } = screenProps;
   return {
     header: CustomHeader,
   };

--- a/src/components/navigation/SwitchNavigator.tsx
+++ b/src/components/navigation/SwitchNavigator.tsx
@@ -34,12 +34,17 @@ export interface ScreenProps {
 }
 
 export default function Navigator() {
-  const { state } = useContext(AppContext);
+  const { state, dispatch, changeTheme } = useContext(AppContext);
   const { theme } = state;
 
   return (
     <ThemeProvider theme={createTheme(theme)}>
-      <AppContainer screenProps={{ theme: createTheme(theme) }} />
+      <AppContainer
+        screenProps={{
+          theme: createTheme(theme),
+          changeTheme,
+        }}
+      />
     </ThemeProvider>
   );
 }

--- a/src/components/screen/__tests__/__snapshots__/Temp.test.tsx.snap
+++ b/src/components/screen/__tests__/__snapshots__/Temp.test.tsx.snap
@@ -38,8 +38,8 @@ exports[`[Temp] render renders without crashing 1`] = `
           Object {
             "alignItems": "center",
             "alignSelf": "center",
-            "backgroundColor": "#069ccd",
-            "borderColor": "#069ccd",
+            "backgroundColor": "rgb(100,199,255)",
+            "borderColor": "rgb(100,199,255)",
             "borderRadius": 4,
             "borderWidth": 2,
             "height": 52,

--- a/src/components/shared/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/Button.test.tsx.snap
@@ -23,8 +23,8 @@ exports[`[Button] renders without crashing 1`] = `
         Object {
           "alignItems": "center",
           "alignSelf": "center",
-          "backgroundColor": "#069ccd",
-          "borderColor": "#069ccd",
+          "backgroundColor": "rgb(100,199,255)",
+          "borderColor": "rgb(100,199,255)",
           "borderRadius": 4,
           "borderWidth": 2,
           "height": 52,

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -1,6 +1,7 @@
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 
 import { AppContext } from '../contexts';
+import { AsyncStorage } from 'react-native';
 import { ThemeType } from '../types';
 
 const AppConsumer = AppContext.Consumer;
@@ -11,6 +12,7 @@ interface Action {
 }
 
 interface Props {
+  theme?: ThemeType;
   navigation?: any;
   children?: any;
 }
@@ -35,7 +37,32 @@ const reducer = (state: State, action: Action) => {
 
 function AppProvider(props: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const value = { state, dispatch };
+
+  // by encapsulating dispatch, it is easier to use (such as passing through screenProps)
+  const changeTheme: (theme?: ThemeType) => void = (theme) => {
+    if (!theme) {
+      theme = state.theme === ThemeType.DARK ? ThemeType.LIGHT : ThemeType.DARK;
+    }
+    dispatch({
+      type: 'change-theme-mode',
+      payload: {
+        theme,
+      },
+    });
+  };
+
+  // initialize theme
+  useEffect(() => {
+    changeTheme(props.theme ? props.theme : initialState.theme);
+  }, [props.theme]);
+
+  // Load font and then use saved theme from local storage
+  const getCurrentThemeType = async () => {
+    const value = (await AsyncStorage.getItem('theme')) as ThemeType;
+    value && changeTheme(value);
+  };
+
+  const value = { state, dispatch, changeTheme };
 
   return (
     <AppContext.Provider value={value}>{props.children}</AppContext.Provider>

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -13,5 +13,9 @@ declare module 'styled-components' {
     fontColor: string;
     tintColor: string;
     lineColor: string;
+    indicatorColor: string;
+    inactiveColor: string;
+    primary: string;
+    primaryLight: string;
   }
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -28,6 +28,8 @@ export interface Theme {
   tintColor: string;
   indicatorColor: string;
   inactiveColor: string;
+  primary: string;
+  primaryLight: string;
 }
 
 const theme = {
@@ -60,10 +62,10 @@ const theme = {
     fontColor: 'white',
     tintColor: '#a3a3a3',
     lineColor: colors.paleGray,
-    indicatorColor: colors.dodgerBlue,
+    indicatorColor: 'white',
     inactiveColor: colors.paleGray,
-    primary: colors.dodgerBlue,
-    primaryLight: colors.skyBlue,
+    primary: colors.darkBackground,
+    primaryLight: colors.darkBackground,
   },
 };
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,10 +1,10 @@
 import { ThemeType } from './types';
 
 const colors = {
-  skyBlue: '#069ccd',
   whiteGray: '#f7f6f3',
   dusk: 'rgb(65,77,107)',
   dodgerBlue: 'rgb(58,139,255)',
+  skyBlue: 'rgb(100,199,255)',
   green: 'rgb(29,211,168)',
   greenBlue: 'rgb(36,205,151)',
   mediumGray: 'rgb(134,154,183)',
@@ -26,6 +26,8 @@ export interface Theme {
   btnDisabled: string;
   fontColor: string;
   tintColor: string;
+  indicatorColor: string;
+  inactiveColor: string;
 }
 
 const theme = {
@@ -41,6 +43,10 @@ const theme = {
     fontColor: 'black',
     tintColor: '#333333',
     lineColor: colors.paleGray,
+    indicatorColor: colors.dodgerBlue,
+    inactiveColor: colors.paleGray,
+    primary: colors.dodgerBlue,
+    primaryLight: colors.skyBlue,
   },
   dark: {
     background: colors.darkBackground,
@@ -54,6 +60,10 @@ const theme = {
     fontColor: 'white',
     tintColor: '#a3a3a3',
     lineColor: colors.paleGray,
+    indicatorColor: colors.dodgerBlue,
+    inactiveColor: colors.paleGray,
+    primary: colors.dodgerBlue,
+    primaryLight: colors.skyBlue,
   },
 };
 


### PR DESCRIPTION
## Description
Currently, the header of `MainTabNavigator` has a different design as it is in original. I've put gradient to make it more similar to the previous design in zeplin.
![image](https://user-images.githubusercontent.com/27461460/65408496-5f422180-de20-11e9-8590-0e67f8c63812.png)


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
