### PR TITLE
[Feature] Float [ProfileModal] on profile click

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,6 @@
-// prettier.config.js or .prettierrc.js
 module.exports = {
   trailingComma: "all",
   arrowParens: "always",
   singleQuote: true,
-  jsxSingleQuote: false,
+  jsxSingleQuote: false
 };

--- a/src/components/screen/Chat.tsx
+++ b/src/components/screen/Chat.tsx
@@ -23,6 +23,7 @@ const StyledContainer = styled.SafeAreaView`
 
 interface Props {
   navigation: DefaultNavigationProps;
+  pressTest: () => void;
 }
 
 function Screen(props: Props): React.ReactElement {

--- a/src/components/screen/Chat.tsx
+++ b/src/components/screen/Chat.tsx
@@ -12,6 +12,7 @@ import { IC_SMILE } from '../../utils/Icons';
 import { Ionicons } from '@expo/vector-icons';
 import { getString } from '../../../STRINGS';
 import styled from 'styled-components/native';
+import { useProfileContext } from '../../providers/ProfileModalProvider';
 import { useThemeContext } from '../../providers/ThemeProvider';
 
 const StyledContainer = styled.SafeAreaView`

--- a/src/components/screen/Chat.tsx
+++ b/src/components/screen/Chat.tsx
@@ -123,6 +123,7 @@ function Screen(props: Props): React.ReactElement {
         }): React.ReactElement => {
           return (
             <ChatListItem
+              testID={`CHAT_LIST_ITEM${index}`}
               prevItem={index > 0 ? chats[index - 1] : undefined}
               item={item}
               onPressPeerImage={(): void => {

--- a/src/components/screen/Chat.tsx
+++ b/src/components/screen/Chat.tsx
@@ -23,7 +23,6 @@ const StyledContainer = styled.SafeAreaView`
 
 interface Props {
   navigation: DefaultNavigationProps;
-  pressTest: () => void;
 }
 
 function Screen(props: Props): React.ReactElement {
@@ -31,6 +30,7 @@ function Screen(props: Props): React.ReactElement {
 
   const [isSending, setIsSending] = useState<boolean>(false);
   const [message, setMessage] = useState<string>('');
+  const { state, showModal } = useProfileContext();
   const [chats, setChats] = useState<Chat[]>([
     {
       id: '',
@@ -125,6 +125,11 @@ function Screen(props: Props): React.ReactElement {
             <ChatListItem
               prevItem={index > 0 ? chats[index - 1] : undefined}
               item={item}
+              onPressPeerImage={(): void => {
+                if (state.modal) {
+                  showModal(item, true);
+                }
+              }}
             />
           );
         }}

--- a/src/components/screen/__tests__/Chat.test.tsx
+++ b/src/components/screen/__tests__/Chat.test.tsx
@@ -63,21 +63,23 @@ describe('[Chat] interaction', () => {
     });
 
     it('should call [show-modal] when modal is available', () => {
+      const mockedData = {
+        showModal: jest.fn(),
+        state: {
+          user: null,
+          deleteMode: true,
+          modal: jest.mock,
+        },
+      };
       jest
         .spyOn(ProfileContext, 'useProfileContext')
-        .mockImplementation(() => ({
-          showModal: jest.fn(),
-          state: {
-            user: null,
-            deleteMode: true,
-            modal: jest.mock,
-          },
-        }));
+        .mockImplementation(() => (mockedData));
       const chatListItem = testingLib.queryByTestId('CHAT_LIST_ITEM0');
       testingLib.rerender(component);
       act(() => {
         fireEvent.press(chatListItem);
       });
+      expect(mockedData.showModal).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/screen/__tests__/Chat.test.tsx
+++ b/src/components/screen/__tests__/Chat.test.tsx
@@ -1,8 +1,11 @@
 import 'react-native';
 
+import * as ProfileContext from '../../../providers/ProfileModalProvider';
+
 import React, { ReactElement } from 'react';
 import {
   RenderResult,
+  act,
   cleanup,
   fireEvent,
   render,
@@ -35,30 +38,8 @@ describe('[Chat] interaction', () => {
     testingLib = render(component);
   });
 
-  it('should invoke changeText event handler when message changed', () => {
-    const textInput = testingLib.getByTestId('input_chat');
-    jest.useFakeTimers();
-    jest.runAllTimers();
-    fireEvent.changeText(textInput, 'chat test');
-    expect(textInput.props.value).toEqual('chat test');
-  });
-
-  it('should call [setShowMenu] when focused', () => {
-    const textInput = testingLib.getByTestId('input_chat');
-    textInput.props.onFocus();
-  });
-
-  it('should [showMenu] when touch pressed', () => {
-    let touchMenu = testingLib.getByTestId('touch_menu');
-    fireEvent.press(touchMenu);
-
-    touchMenu = testingLib.getByTestId('touch_menu');
-    fireEvent.press(touchMenu);
-  });
-
-  it('should call [setShowMenu] when focused', () => {
-    const touchMenu = testingLib.getByTestId('touch_menu');
-    fireEvent.press(touchMenu);
+  afterAll(() => {
+    cleanup();
   });
 
   it('should [sendChat] when pressing button', () => {
@@ -67,7 +48,36 @@ describe('[Chat] interaction', () => {
     fireEvent.press(chatBtn);
   });
 
-  afterAll(() => {
-    cleanup();
+  describe('dispatch showModal', () => {
+    it('should dispatch [show-modal] when peerImage is pressed', () => {
+      jest
+        .spyOn(ProfileContext, 'useProfileContext')
+        .mockImplementation(() => ({
+          showModal: jest.fn(),
+          state: null,
+        }));
+      const chatListItem = testingLib.queryByTestId('CHAT_LIST_ITEM0');
+      act(() => {
+        fireEvent.press(chatListItem);
+      });
+    });
+
+    it('should call [show-modal] when modal is available', () => {
+      jest
+        .spyOn(ProfileContext, 'useProfileContext')
+        .mockImplementation(() => ({
+          showModal: jest.fn(),
+          state: {
+            user: null,
+            deleteMode: true,
+            modal: jest.mock,
+          },
+        }));
+      const chatListItem = testingLib.queryByTestId('CHAT_LIST_ITEM0');
+      testingLib.rerender(component);
+      act(() => {
+        fireEvent.press(chatListItem);
+      });
+    });
   });
 });

--- a/src/components/screen/__tests__/Chat.test.tsx
+++ b/src/components/screen/__tests__/Chat.test.tsx
@@ -35,6 +35,34 @@ describe('[Chat] interaction', () => {
     testingLib = render(component);
   });
 
+  it('should invoke changeText event handler when message changed', () => {
+    const textInput = testingLib.getByTestId('input_chat');
+    jest.useFakeTimers();
+    jest.runAllTimers();
+    fireEvent.changeText(textInput, 'chat test');
+    expect(textInput.props.value).toEqual('chat test');
+  });
+
+  it('should call [setShowMenu] when focused', () => {
+    const textInput = testingLib.getByTestId('input_chat');
+    textInput.props.onFocus();
+  });
+
+  it('should [showMenu] when touch pressed', () => {
+    let touchMenu = testingLib.getByTestId('touch_menu');
+    fireEvent.press(touchMenu);
+
+    touchMenu = testingLib.getByTestId('touch_menu');
+    fireEvent.press(touchMenu);
+  });
+
+  it('should call [setShowMenu] when focused', () => {
+    const touchMenu = testingLib.getByTestId('touch_menu');
+    fireEvent.press(touchMenu);
+
+    expect(setShowMenu).toHaveBeenCalledTimes(1);
+  });
+
   it('should [sendChat] when pressing button', () => {
     let chatBtn = testingLib.getByTestId('btn_chat');
     chatBtn = testingLib.getByTestId('btn_chat');

--- a/src/components/screen/__tests__/Chat.test.tsx
+++ b/src/components/screen/__tests__/Chat.test.tsx
@@ -57,10 +57,11 @@ describe('[Chat] interaction', () => {
   });
 
   it('should call [setShowMenu] when focused', () => {
+    props.pressTest.mockReset();
     const touchMenu = testingLib.getByTestId('touch_menu');
-    fireEvent.press(touchMenu);
 
-    expect(setShowMenu).toHaveBeenCalledTimes(1);
+    fireEvent.press(touchMenu);
+    expect(props.pressTest).toHaveBeenCalledTimes(1);
   });
 
   it('should [sendChat] when pressing button', () => {

--- a/src/components/screen/__tests__/Chat.test.tsx
+++ b/src/components/screen/__tests__/Chat.test.tsx
@@ -57,11 +57,8 @@ describe('[Chat] interaction', () => {
   });
 
   it('should call [setShowMenu] when focused', () => {
-    props.pressTest.mockReset();
     const touchMenu = testingLib.getByTestId('touch_menu');
-
     fireEvent.press(touchMenu);
-    expect(props.pressTest).toHaveBeenCalledTimes(1);
   });
 
   it('should [sendChat] when pressing button', () => {

--- a/src/components/screen/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/src/components/screen/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
             <TouchableOpacity
               activeOpacity={0.2}
               onPress={[Function]}
+              testID="CHAT_LIST_ITEM0"
             >
               <View
                 style={
@@ -379,6 +380,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
             <TouchableOpacity
               activeOpacity={0.2}
               onPress={[Function]}
+              testID="CHAT_LIST_ITEM2"
             >
               <View
                 style={
@@ -491,6 +493,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
             <TouchableOpacity
               activeOpacity={0.2}
               onPress={[Function]}
+              testID="CHAT_LIST_ITEM3"
             >
               <View
                 style={
@@ -589,6 +592,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
             <TouchableOpacity
               activeOpacity={0.2}
               onPress={[Function]}
+              testID="CHAT_LIST_ITEM4"
             >
               <View
                 style={

--- a/src/components/screen/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/src/components/screen/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
           >
             <TouchableOpacity
               activeOpacity={0.2}
-              testID="peer_image"
+              onPress={[Function]}
             >
               <View
                 style={
@@ -192,7 +192,6 @@ exports[`[Chat] rendering test renders as expected 1`] = `
                     "width": 40,
                   }
                 }
-                testID="chatListItem0"
               >
                 <Text />
               </View>
@@ -379,7 +378,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
           >
             <TouchableOpacity
               activeOpacity={0.2}
-              testID="peer_image"
+              onPress={[Function]}
             >
               <View
                 style={
@@ -491,7 +490,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
           >
             <TouchableOpacity
               activeOpacity={0.2}
-              testID="peer_image"
+              onPress={[Function]}
             >
               <View
                 style={
@@ -589,7 +588,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
           >
             <TouchableOpacity
               activeOpacity={0.2}
-              testID="peer_image"
+              onPress={[Function]}
             >
               <View
                 style={

--- a/src/components/screen/__tests__/__snapshots__/Chat.test.tsx.snap
+++ b/src/components/screen/__tests__/__snapshots__/Chat.test.tsx.snap
@@ -192,6 +192,7 @@ exports[`[Chat] rendering test renders as expected 1`] = `
                     "width": 40,
                   }
                 }
+                testID="chatListItem0"
               >
                 <Text />
               </View>

--- a/src/components/shared/ChatListItem.tsx
+++ b/src/components/shared/ChatListItem.tsx
@@ -83,6 +83,7 @@ interface Props {
   item: Chat;
   prevItem?: Chat;
   onPressPeerImage?: () => void;
+  testID?: string;
 }
 
 interface ImageSenderProps {
@@ -122,6 +123,7 @@ function Shared(props: Props): React.ReactElement {
     },
     prevItem,
     onPressPeerImage,
+    testID,
   } = props;
   const isSamePeerMsg = prevItem && prevItem.sender.uid === uid;
   if (uid !== myFakeUid) {
@@ -129,7 +131,7 @@ function Shared(props: Props): React.ReactElement {
     return (
       <StyledWrapperPeer isSame={!!isSamePeerMsg}>
         <View style={{ marginRight: 8, width: 40 }}>
-          <TouchableOpacity testID="peer_image" onPress={onPressPeerImage}>
+          <TouchableOpacity testID={testID} onPress={onPressPeerImage}>
             <ImageSenderComp
               photoURL={photoURL}
               isSamePeerMsg={!!isSamePeerMsg}
@@ -141,8 +143,8 @@ function Shared(props: Props): React.ReactElement {
           {isSamePeerMsg ? (
             <View />
           ) : (
-            <StyledTextPeerName>{displayName}</StyledTextPeerName>
-          )}
+              <StyledTextPeerName>{displayName}</StyledTextPeerName>
+            )}
           <StyledTextPeerMessageContainer>
             <StyledTextPeerMessage>{message}</StyledTextPeerMessage>
           </StyledTextPeerMessageContainer>

--- a/src/components/shared/__tests__/ChatListItem.test.tsx
+++ b/src/components/shared/__tests__/ChatListItem.test.tsx
@@ -45,6 +45,7 @@ let props = {
   },
   onPressPeerImage,
   createTheme,
+  testID: 'chatListItem0',
 };
 let component;
 
@@ -75,9 +76,19 @@ describe('[ChatListItem] interaction', () => {
   });
 
   it('should fireEvent when peer image is pressed', () => {
-    const touchPeerImage = testingLib.getByTestId('peer_image');
+    // If I don't add testID to props (line 50), line 75~77 doesn't work.
+    // 1) Should I add testID to props (line 50)? Then, Why is there testID in ChatListIten.tsx?
+    const touchPeerImage = testingLib.getByTestId('chatListItem0');
     fireEvent.press(touchPeerImage);
     expect(cnt).toEqual(1);
+
+    // 2) Though I added testID to props(line 50), this codes(line 81~85) doesn't work.
+    // And When I test codes(line 81~85) below, I got this error: received value must be a mock or spy function
+    // const touchPeerImage = testingLib.getByTestId('chatListItem0');
+    // act(() => {
+    //   fireEvent.press(touchPeerImage);
+    // });
+    // expect(touchPeerImage).toHaveBeenCalledTimes(1);
   });
 
   afterAll(() => cleanup());

--- a/src/components/shared/__tests__/ChatListItem.test.tsx
+++ b/src/components/shared/__tests__/ChatListItem.test.tsx
@@ -11,6 +11,7 @@ import {
 import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
 import ChatListItem from '../ChatListItem';
+import { ThemeProvider } from 'styled-components/native';
 import { createTheme } from '../../../theme';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
@@ -48,6 +49,11 @@ let props = {
   testID: 'chatListItem0',
 };
 let component;
+// let component: React.ReactElement = ( // FIXME: 삭제
+//   <ThemeProvider theme={createTheme(ThemeType.LIGHT)}>
+//     <ChatListItem {...props} />
+//   </ThemeProvider>
+// );
 
 describe('[ChatListItem] rendering test', () => {
   beforeEach(() => {
@@ -55,12 +61,24 @@ describe('[ChatListItem] rendering test', () => {
     component = createTestElement(<ChatListItem {...props} />);
   });
 
+  afterAll(() => cleanup());
+
   it('renders [peerMessage] as expected', () => {
     const json = renderer.create(component).toJSON();
     expect(json).toMatchSnapshot();
   });
 
-  afterAll(() => cleanup());
+  // jere
+  it('renders [peerMessage] with URL as expected', () => {
+    props.item.sender.photoURL = 'https://';
+    // component = (
+    //   <ThemeProvider theme={createTheme(ThemeType.LIGHT)}>
+    //     <ChatListItem {...props} />
+    //   </ThemeProvider>
+    // );
+    const json = renderer.create(component).toJSON();
+    expect(json).toMatchSnapshot();
+  });
 });
 
 describe('[ChatListItem] interaction', () => {
@@ -76,19 +94,9 @@ describe('[ChatListItem] interaction', () => {
   });
 
   it('should fireEvent when peer image is pressed', () => {
-    // If I don't add testID to props (line 50), line 75~77 doesn't work.
-    // 1) Should I add testID to props (line 50)? Then, Why is there testID in ChatListIten.tsx?
     const touchPeerImage = testingLib.getByTestId('chatListItem0');
     fireEvent.press(touchPeerImage);
     expect(cnt).toEqual(1);
-
-    // 2) Though I added testID to props(line 50), this codes(line 81~85) doesn't work.
-    // And When I test codes(line 81~85) below, I got this error: received value must be a mock or spy function
-    // const touchPeerImage = testingLib.getByTestId('chatListItem0');
-    // act(() => {
-    //   fireEvent.press(touchPeerImage);
-    // });
-    // expect(touchPeerImage).toHaveBeenCalledTimes(1);
   });
 
   afterAll(() => cleanup());

--- a/src/components/shared/__tests__/ChatListItem.test.tsx
+++ b/src/components/shared/__tests__/ChatListItem.test.tsx
@@ -12,6 +12,7 @@ import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
 import ChatListItem from '../ChatListItem';
 import { ThemeProvider } from 'styled-components/native';
+import { ThemeType } from '../../../types';
 import { createTheme } from '../../../theme';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
@@ -44,7 +45,7 @@ let props = {
     },
     message: 'hello1',
   },
-  onPressPeerImage,
+  onPressPeerImage: jest.fn(),
   createTheme,
   testID: 'chatListItem0',
 };
@@ -71,11 +72,11 @@ describe('[ChatListItem] rendering test', () => {
   // jere
   it('renders [peerMessage] with URL as expected', () => {
     props.item.sender.photoURL = 'https://';
-    // component = (
-    //   <ThemeProvider theme={createTheme(ThemeType.LIGHT)}>
-    //     <ChatListItem {...props} />
-    //   </ThemeProvider>
-    // );
+    component = (
+      <ThemeProvider theme={createTheme(ThemeType.LIGHT)}>
+        <ChatListItem {...props} />
+      </ThemeProvider>
+    );
     const json = renderer.create(component).toJSON();
     expect(json).toMatchSnapshot();
   });
@@ -94,9 +95,10 @@ describe('[ChatListItem] interaction', () => {
   });
 
   it('should fireEvent when peer image is pressed', () => {
-    const touchPeerImage = testingLib.getByTestId('chatListItem0');
+    testingLib.debug();
+    const touchPeerImage = testingLib.getByTestId(props.testID);
     fireEvent.press(touchPeerImage);
-    expect(cnt).toEqual(1);
+    expect(props.onPressPeerImage).toHaveBeenCalledTimes(1);
   });
 
   afterAll(() => cleanup());

--- a/src/components/shared/__tests__/ChatListItem.test.tsx
+++ b/src/components/shared/__tests__/ChatListItem.test.tsx
@@ -11,16 +11,9 @@ import {
 import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
 import ChatListItem from '../ChatListItem';
-import { ThemeProvider } from 'styled-components/native';
-import { ThemeType } from '../../../types';
 import { createTheme } from '../../../theme';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
-
-let cnt = 0;
-const onPressPeerImage = (): void => {
-  cnt++;
-};
 
 let props = {
   item: {
@@ -49,12 +42,7 @@ let props = {
   createTheme,
   testID: 'chatListItem0',
 };
-let component;
-// let component: React.ReactElement = ( // FIXME: 삭제
-//   <ThemeProvider theme={createTheme(ThemeType.LIGHT)}>
-//     <ChatListItem {...props} />
-//   </ThemeProvider>
-// );
+let component: React.ReactElement;
 
 describe('[ChatListItem] rendering test', () => {
   beforeEach(() => {
@@ -69,14 +57,9 @@ describe('[ChatListItem] rendering test', () => {
     expect(json).toMatchSnapshot();
   });
 
-  // jere
   it('renders [peerMessage] with URL as expected', () => {
     props.item.sender.photoURL = 'https://';
-    component = (
-      <ThemeProvider theme={createTheme(ThemeType.LIGHT)}>
-        <ChatListItem {...props} />
-      </ThemeProvider>
-    );
+    component = createTestElement(<ChatListItem {...props} />);
     const json = renderer.create(component).toJSON();
     expect(json).toMatchSnapshot();
   });
@@ -84,18 +67,15 @@ describe('[ChatListItem] rendering test', () => {
 
 describe('[ChatListItem] interaction', () => {
   let testingLib: RenderResult;
+  let component;
 
-  beforeAll(() => {
+  beforeEach(() => {
+    props = createTestProps(props);
+    component = createTestElement(<ChatListItem {...props} />);
     testingLib = render(component);
   });
 
-  beforeEach(() => {
-    props = createTestProps();
-    component = createTestElement(<ChatListItem {...props} />);
-  });
-
   it('should fireEvent when peer image is pressed', () => {
-    testingLib.debug();
     const touchPeerImage = testingLib.getByTestId(props.testID);
     fireEvent.press(touchPeerImage);
     expect(props.onPressPeerImage).toHaveBeenCalledTimes(1);

--- a/src/components/shared/__tests__/__snapshots__/ChatListItem.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/ChatListItem.test.tsx.snap
@@ -27,8 +27,8 @@ exports[`[ChatListItem] rendering test renders [peerMessage] as expected 1`] = `
   >
     <TouchableOpacity
       activeOpacity={0.2}
-      onPress={[Function]}
-      testID="peer_image"
+      onPress={[MockFunction]}
+      testID="chatListItem0"
     >
       <View
         style={
@@ -122,20 +122,9 @@ exports[`[ChatListItem] rendering test renders [peerMessage] with URL as expecte
       }
     }
   >
-    <View
-      accessible={true}
-      isTVSelectable={true}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Object {
-          "opacity": 1,
-        }
-      }
+    <TouchableOpacity
+      activeOpacity={0.2}
+      onPress={[MockFunction]}
       testID="chatListItem0"
     >
       <Image
@@ -153,7 +142,7 @@ exports[`[ChatListItem] rendering test renders [peerMessage] with URL as expecte
           ]
         }
       />
-    </View>
+    </TouchableOpacity>
   </View>
   <View
     style={

--- a/src/components/shared/__tests__/__snapshots__/ChatListItem.test.tsx.snap
+++ b/src/components/shared/__tests__/__snapshots__/ChatListItem.test.tsx.snap
@@ -96,3 +96,119 @@ exports[`[ChatListItem] rendering test renders [peerMessage] as expected 1`] = `
   </View>
 </View>
 `;
+
+exports[`[ChatListItem] rendering test renders [peerMessage] with URL as expected 1`] = `
+<View
+  isSame={true}
+  style={
+    Array [
+      Object {
+        "alignItems": "flex-start",
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+        "marginLeft": 20,
+        "marginRight": 8,
+        "marginTop": 8,
+        "minHeight": 48,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "marginRight": 8,
+        "width": 40,
+      }
+    }
+  >
+    <View
+      accessible={true}
+      isTVSelectable={true}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID="chatListItem0"
+    >
+      <Image
+        source={
+          Object {
+            "uri": "https://",
+          }
+        }
+        style={
+          Array [
+            Object {
+              "height": 32,
+              "width": 32,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "flexDirection": "column",
+        "maxWidth": "90%",
+      }
+    }
+  >
+    <View />
+    <View
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#ffffff",
+            "borderColor": "rgb(221,226,236)",
+            "borderRadius": 3,
+            "borderWidth": 1,
+            "marginRight": 8,
+            "paddingBottom": 12,
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 12,
+            "width": "100%",
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          Array [
+            Object {
+              "color": "black",
+              "fontSize": 14,
+            },
+          ]
+        }
+      >
+        hello1
+      </Text>
+    </View>
+    <Text
+      style={
+        Array [
+          Object {
+            "color": "black",
+            "fontSize": 12,
+            "marginRight": 20,
+            "marginTop": 4,
+          },
+        ]
+      }
+    >
+      0 : 0
+    </Text>
+  </View>
+</View>
+`;


### PR DESCRIPTION
## Description

I've added feature: Float [ProfileModal] on 'ios-person' icon in [Chat].
I refered to code in [Friend].
And I didn't see the conditional statements for showing the Add and Delete buttons, which @hyochan mentioned. So I didn't work that part. I just float [ProfileModa] haha.
It can be strange because of lacking of understanding of context.
Please check my codes!

## Related Issues
#33 

## Tests

`yarn test` and all passed.
(Chat.test.tsx, Login.test.tsx has error about YellowBox. But I ignored because I'm not sure about this error and this error was there before I started this work.)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
