### PR TITLE
enforce vscode to use always-relative-import feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,7 @@
   "prettier.singleQuote": true,
   "prettier.trailingComma": "all",
   "prettier.arrowParens": "always",
-  "prettier.jsxSingleQuote": false
+  "prettier.jsxSingleQuote": false,
+  "javascript.preferences.importModuleSpecifier": "relative",
+  "typescript.preferences.importModuleSpecifier": "relative",
 }


### PR DESCRIPTION
to avoid unexpected auto-complete error caused by non-relative imports

## Description

When we use auto completion for import packages, sometimes vscode import it as absolute path. and that makes unexpected problem and we get crazy
this PR will save us from this madness

## Related Issues

none

## Tests

No need

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
