### PR TITLE
Enhnace header recognition and remove react-navigation legacy

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -12,7 +12,6 @@
     "@react-navigation/stack",
     "react-native-svg",
     "react-native-webview",
-    "react-navigation-stack",
     "react-native-svg"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "react-native-tab-view": "^2.11.0",
     "react-native-web": "^0.11.7",
     "react-native-webview": "7.4.3",
-    "react-navigation": "^4.0.10",
-    "react-navigation-stack": "2.0.2",
     "sentry-expo": "^2.0.1",
     "styled-components": "^4.4.1"
   },

--- a/src/components/screen/ChangePw/index.tsx
+++ b/src/components/screen/ChangePw/index.tsx
@@ -1,4 +1,4 @@
-import { Alert, EmitterSubscription, Keyboard, KeyboardEvent, View } from 'react-native';
+import { Alert, EmitterSubscription, Keyboard, KeyboardEvent, SafeAreaView } from 'react-native';
 import {
   CloseButton,
   Header,
@@ -14,15 +14,25 @@ import React, {
 } from 'react';
 
 import { Button } from '@dooboo-ui/native';
+import Constants from 'expo-constants';
 import { Ionicons } from '@expo/vector-icons';
 import { MainStackNavigationProps } from '../../navigation/MainStackNavigator';
-import { SafeAreaView } from 'react-navigation';
 import { getString } from '../../../../STRINGS';
+import { isIPhoneXSize } from '../../../utils/Styles';
+import styled from 'styled-components/native';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
 export interface Props {
   navigation: MainStackNavigationProps<'ChangePw'>;
 }
+
+const StyledKeyboardAvoidingView = styled.KeyboardAvoidingView`
+  flex: 1;
+  justify-content: center;
+  align-self: stretch;
+  flex-direction: column;
+  align-items: center;
+`;
 
 const ChangePwHeader = (props: Props): ReactElement => {
   const { navigation } = props;
@@ -90,53 +100,65 @@ function ChangePw(props: Props): ReactElement {
     };
   }, []);
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background, paddingBottom: keyboardOffset }}>
-      {isValidCurrentPw ? (
-        <InnerContainer>
-          <StyledTextInput
-            key="newPwTextInput"
-            testID="newPwTextInput"
-            isPassword
-            onTextChanged={(pw): void => setNewPw(pw)}
-            txtLabel={getString('PASSWORD_NEW')}
-          />
-          <StyledTextInput
-            key="validationWordTextInput"
-            testID="validationWordTextInput"
-            isPassword
-            onTextChanged={(pw): void => setValidationWord(pw)}
-            txtLabel={getString('PASSWORD_NEW_REPEAT')}
-          />
-        </InnerContainer>
-      ) : (
-        <InnerContainer>
-          <StyledTextInput
-            key="currentPwTextInput"
-            testID="currentPwTextInput"
-            isPassword
-            onTextChanged={(pw): void => setCurrentPw(pw)}
-            txtLabel={getString('PASSWORD_CURRENT')}
-          />
-        </InnerContainer>
-      )}
-      <Button
-        testID="checkCurrentPwBtn"
-        onPress={isValidCurrentPw ? changePassword : validateCurrent}
-        // containerStyle={{
-        //   width: '100%',
-        // }}
-        style={{
-          backgroundColor: theme.btnPrimary,
-          borderWidth: 0,
-          height: 56,
-          width: '100%',
-        }}
-        textStyle={{
-          color: theme.btnPrimaryFont,
-          fontSize: 16,
-        }}
-        text={isValidCurrentPw ? getString('CONFIRM') : getString('NEXT')}
-      />
+    <SafeAreaView
+      style={{
+        flex: 1,
+        backgroundColor: theme.background,
+        paddingBottom: keyboardOffset,
+      }}>
+      <StyledKeyboardAvoidingView
+        keyboardVerticalOffset={isIPhoneXSize
+          ? Constants.statusBarHeight + 52
+          : Constants.statusBarHeight}
+        behavior={'padding'}
+      >
+        {isValidCurrentPw ? (
+          <InnerContainer>
+            <StyledTextInput
+              key="newPwTextInput"
+              testID="newPwTextInput"
+              isPassword
+              onTextChanged={(pw): void => setNewPw(pw)}
+              txtLabel={getString('PASSWORD_NEW')}
+            />
+            <StyledTextInput
+              key="validationWordTextInput"
+              testID="validationWordTextInput"
+              isPassword
+              onTextChanged={(pw): void => setValidationWord(pw)}
+              txtLabel={getString('PASSWORD_NEW_REPEAT')}
+            />
+          </InnerContainer>
+        ) : (
+          <InnerContainer>
+            <StyledTextInput
+              key="currentPwTextInput"
+              testID="currentPwTextInput"
+              isPassword
+              onTextChanged={(pw): void => setCurrentPw(pw)}
+              txtLabel={getString('PASSWORD_CURRENT')}
+            />
+          </InnerContainer>
+        )}
+        <Button
+          testID="checkCurrentPwBtn"
+          onPress={isValidCurrentPw ? changePassword : validateCurrent}
+          containerStyle={{
+            width: '100%',
+          }}
+          style={{
+            backgroundColor: theme.btnPrimary,
+            borderWidth: 0,
+            height: 56,
+            width: '100%',
+          }}
+          textStyle={{
+            color: theme.btnPrimaryFont,
+            fontSize: 16,
+          }}
+          text={isValidCurrentPw ? getString('CONFIRM') : getString('NEXT')}
+        />
+      </StyledKeyboardAvoidingView>
     </SafeAreaView>
   );
 }

--- a/src/components/screen/ChangePw/styles.ts
+++ b/src/components/screen/ChangePw/styles.ts
@@ -25,8 +25,9 @@ export const CloseButton = styled.TouchableOpacity`
 `;
 
 export const InnerContainer = styled.View`
-  padding: 15px;
+  padding: 0 24px;
   flex: 1;
+  width: 100%;
 `;
 
 export const StyledTextInput = styled(TextInput).attrs(({ theme }) => ({

--- a/src/components/screen/Chat.tsx
+++ b/src/components/screen/Chat.tsx
@@ -11,11 +11,11 @@ import ChatListItem from '../shared/ChatListItem';
 import Constants from 'expo-constants';
 import EmptyListItem from '../shared/EmptyListItem';
 import GiftedChat from '../shared/GiftedChat';
-import { Header } from 'react-navigation-stack';
 import { IC_SMILE } from '../../utils/Icons';
 import { Ionicons } from '@expo/vector-icons';
 import { MainStackNavigationProps } from '../navigation/MainStackNavigator';
 import { getString } from '../../../STRINGS';
+import { isIPhoneXSize } from '../../utils/Styles';
 import styled from 'styled-components/native';
 import { useProfileContext } from '../../providers/ProfileModalProvider';
 import { useThemeContext } from '@dooboo-ui/native-theme';
@@ -123,8 +123,9 @@ function Screen(): React.ReactElement {
         borderColor={theme.lineColor}
         backgroundColor={theme.background}
         fontColor={theme.fontColor}
-        // @ts-ignore
-        keyboardOffset={Constants.statusBarHeight + Header.HEIGHT}
+        keyboardOffset={isIPhoneXSize
+          ? Constants.statusBarHeight + 40
+          : Constants.statusBarHeight}
         message={message}
         placeholder={getString('WRITE_MESSAGE')}
         placeholderTextColor={theme.placeholder}

--- a/src/components/screen/Setting/styles.ts
+++ b/src/components/screen/Setting/styles.ts
@@ -8,15 +8,16 @@ export const Container = styled.View`
 
 export const HeaderContainer = styled.View`
   background-color: ${({ theme }): string => theme.background};
-  height: 52px;
+  height: 40px;
   justify-content: center;
-  margin-left: 10px;
+  margin-left: 12px;
   border-bottom-width: 1;
   border-bottom-color: ${({ theme }): string => theme.lineColor};
 `;
 
 export const SectionHeader = styled.Text`
   color: ${({ theme }): string => theme.fontSubColor};
+  margin-left: 2px;
 `;
 
 export const ItemContainer = styled.TouchableOpacity`

--- a/src/components/screen/__tests__/__snapshots__/ChangePw.test.tsx.snap
+++ b/src/components/screen/__tests__/__snapshots__/ChangePw.test.tsx.snap
@@ -10,30 +10,31 @@ exports[`[ChangePw] screen renders without crashing 1`] = `
     }
   }
 >
-  <View
-    pointerEvents="box-none"
+  <SafeAreaView
     style={
       Object {
         "backgroundColor": "#ffffff",
         "flex": 1,
         "paddingBottom": 0,
-        "paddingLeft": 0,
-        "paddingRight": 0,
-        "paddingTop": 20,
       }
     }
   >
     <View
       style={
         Array [
+          Array [
+            Object {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "flexBasis": 0,
+              "flexDirection": "column",
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "justifyContent": "center",
+            },
+          ],
           Object {
-            "flexBasis": 0,
-            "flexGrow": 1,
-            "flexShrink": 1,
-            "paddingBottom": 15,
-            "paddingLeft": 15,
-            "paddingRight": 15,
-            "paddingTop": 15,
+            "paddingBottom": 0,
           },
         ]
       }
@@ -42,124 +43,146 @@ exports[`[ChangePw] screen renders without crashing 1`] = `
         style={
           Array [
             Object {
-              "alignItems": "flex-start",
-              "alignSelf": "stretch",
-              "flexDirection": "column",
-              "justifyContent": "flex-start",
-            },
-          ]
-        }
-      >
-        <Text
-          focused={false}
-          style={
-            Array [
-              Object {
-                "color": "#676c7a",
-                "fontSize": 12,
-                "marginBottom": 8,
-              },
-            ]
-          }
-        >
-          Enter Current Password
-        </Text>
-        <View
-          isFocused={false}
-          style={
-            Array [
-              Object {
-                "alignItems": "center",
-                "borderColor": "#d3d8e8",
-                "borderRadius": 3,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "justifyContent": "center",
-                "marginBottom": 8,
-              },
-            ]
-          }
-        >
-          <TextInput
-            allowFontScaling={true}
-            autoCapitalize="none"
-            autoCorrect={false}
-            focused={false}
-            placeholderTextColor="#676c7a"
-            rejectResponderTermination={true}
-            secureTextEntry={true}
-            style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "alignSelf": "stretch",
-                  "borderColor": "black",
-                  "borderStyle": "solid",
-                  "borderWidth": 0,
-                  "color": "#151A25",
-                  "flexBasis": 0,
-                  "flexDirection": "row",
-                  "flexGrow": 1,
-                  "flexShrink": 1,
-                  "fontSize": 16,
-                  "justifyContent": "flex-start",
-                  "paddingBottom": 22,
-                  "paddingLeft": 20,
-                  "paddingRight": 20,
-                  "paddingTop": 22,
-                },
-              ]
-            }
-            testID="currentPwTextInput"
-            textContentType="none"
-            underlineColorAndroid="transparent"
-          />
-        </View>
-      </View>
-    </View>
-    <TouchableOpacity
-      activeOpacity={0.2}
-      testID="checkCurrentPwBtn"
-    >
-      <View
-        style={
-          Array [
-            Object {
-              "alignItems": "center",
-              "alignSelf": "center",
-              "borderColor": "blue",
-              "flexDirection": "row",
-              "height": 52,
-              "justifyContent": "center",
-            },
-            Object {
-              "backgroundColor": "#1E6EFA",
-              "borderWidth": 0,
-              "height": 56,
+              "flexBasis": 0,
+              "flexGrow": 1,
+              "flexShrink": 1,
+              "paddingBottom": 0,
+              "paddingLeft": 24,
+              "paddingRight": 24,
+              "paddingTop": 0,
               "width": "100%",
             },
           ]
         }
       >
-        <Text
+        <View
           style={
             Array [
               Object {
-                "color": "#069ccd",
-                "fontSize": 16,
-              },
-              Object {
-                "color": "#ffffff",
-                "fontSize": 16,
+                "alignItems": "flex-start",
+                "alignSelf": "stretch",
+                "flexDirection": "column",
+                "justifyContent": "flex-start",
               },
             ]
           }
         >
-          Next
-        </Text>
+          <Text
+            focused={false}
+            style={
+              Array [
+                Object {
+                  "color": "#676c7a",
+                  "fontSize": 12,
+                  "marginBottom": 8,
+                },
+              ]
+            }
+          >
+            Enter Current Password
+          </Text>
+          <View
+            isFocused={false}
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "borderColor": "#d3d8e8",
+                  "borderRadius": 3,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "marginBottom": 8,
+                },
+              ]
+            }
+          >
+            <TextInput
+              allowFontScaling={true}
+              autoCapitalize="none"
+              autoCorrect={false}
+              focused={false}
+              placeholderTextColor="#676c7a"
+              rejectResponderTermination={true}
+              secureTextEntry={true}
+              style={
+                Array [
+                  Object {
+                    "alignItems": "center",
+                    "alignSelf": "stretch",
+                    "borderColor": "black",
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "color": "#151A25",
+                    "flexBasis": 0,
+                    "flexDirection": "row",
+                    "flexGrow": 1,
+                    "flexShrink": 1,
+                    "fontSize": 16,
+                    "justifyContent": "flex-start",
+                    "paddingBottom": 22,
+                    "paddingLeft": 20,
+                    "paddingRight": 20,
+                    "paddingTop": 22,
+                  },
+                ]
+              }
+              testID="currentPwTextInput"
+              textContentType="none"
+              underlineColorAndroid="transparent"
+            />
+          </View>
+        </View>
       </View>
-    </TouchableOpacity>
-  </View>
+      <TouchableOpacity
+        activeOpacity={0.2}
+        style={
+          Object {
+            "width": "100%",
+          }
+        }
+        testID="checkCurrentPwBtn"
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "alignSelf": "center",
+                "borderColor": "blue",
+                "flexDirection": "row",
+                "height": 52,
+                "justifyContent": "center",
+              },
+              Object {
+                "backgroundColor": "#1E6EFA",
+                "borderWidth": 0,
+                "height": 56,
+                "width": "100%",
+              },
+            ]
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#069ccd",
+                  "fontSize": 16,
+                },
+                Object {
+                  "color": "#ffffff",
+                  "fontSize": 16,
+                },
+              ]
+            }
+          >
+            Next
+          </Text>
+        </View>
+      </TouchableOpacity>
+    </View>
+  </SafeAreaView>
 </View>
 `;
 

--- a/src/components/screen/__tests__/__snapshots__/Setting.test.tsx.snap
+++ b/src/components/screen/__tests__/__snapshots__/Setting.test.tsx.snap
@@ -81,9 +81,9 @@ exports[`[Setting] screen renders without crashing 1`] = `
               "backgroundColor": "#ffffff",
               "borderBottomColor": "#d3d8e8",
               "borderBottomWidth": 1,
-              "height": 52,
+              "height": 40,
               "justifyContent": "center",
-              "marginLeft": 10,
+              "marginLeft": 12,
             },
           ]
         }
@@ -93,6 +93,7 @@ exports[`[Setting] screen renders without crashing 1`] = `
             Array [
               Object {
                 "color": "#1E6EFA",
+                "marginLeft": 2,
               },
             ]
           }
@@ -237,9 +238,9 @@ exports[`[Setting] screen renders without crashing 2`] = `
               "backgroundColor": "#ffffff",
               "borderBottomColor": "#d3d8e8",
               "borderBottomWidth": 1,
-              "height": 52,
+              "height": 40,
               "justifyContent": "center",
-              "marginLeft": 10,
+              "marginLeft": 12,
             },
           ]
         }
@@ -249,6 +250,7 @@ exports[`[Setting] screen renders without crashing 2`] = `
             Array [
               Object {
                 "color": "#1E6EFA",
+                "marginLeft": 2,
               },
             ]
           }
@@ -397,9 +399,9 @@ exports[`[Setting] screen renders without crashing 3`] = `
               "backgroundColor": "#ffffff",
               "borderBottomColor": "#d3d8e8",
               "borderBottomWidth": 1,
-              "height": 52,
+              "height": 40,
               "justifyContent": "center",
-              "marginLeft": 10,
+              "marginLeft": 12,
             },
           ]
         }
@@ -409,6 +411,7 @@ exports[`[Setting] screen renders without crashing 3`] = `
             Array [
               Object {
                 "color": "#1E6EFA",
+                "marginLeft": 2,
               },
             ]
           }

--- a/src/utils/Styles.ts
+++ b/src/utils/Styles.ts
@@ -1,4 +1,4 @@
-import { Dimensions } from 'react-native';
+import { Dimensions, Platform, ScaledSize } from 'react-native';
 
 const { width, height } = Dimensions.get('window');
 let calRatio = width <= height ? 16 * (width / height) : 16 * (height / width);
@@ -20,3 +20,23 @@ if (width <= height) {
 export const screenWidth = width;
 export const screenHeight = height;
 export const ratio = calRatio / (360 / 9);
+
+export function isIPhoneXSize(dim: ScaledSize): boolean {
+  return dim.height === 812 || dim.width === 812;
+}
+
+export function isIPhoneXrSize(dim: ScaledSize): boolean {
+  return dim.height === 896 || dim.width === 896;
+}
+
+export function isIphoneX(): boolean {
+  const dim = Dimensions.get('window');
+
+  return (
+    // This has to be iOS
+    Platform.OS === 'ios' &&
+
+    // Check either, iPhone X or XR
+    (isIPhoneXSize(dim) || isIPhoneXrSize(dim))
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8440,14 +8440,7 @@ react-native-webview@7.4.3:
     stacktrace-parser "^0.1.3"
     whatwg-fetch "^3.0.0"
 
-react-navigation-stack@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-2.0.2.tgz#ae2e4556a33bd0f6db14ec1f2bff390e32378ba0"
-  integrity sha512-DDh1vEC0Sp3nNIsuFxXk5hM0eTH+PgrjDcoivyZ2+EubQYsJISB5Cw6jOyy+1i0LbfBs8YouZ+1fJsbPo3IyOw==
-  dependencies:
-    color "^3.1.2"
-
-react-navigation@*, react-navigation@^4.0.10:
+react-navigation@*:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-4.0.10.tgz#ddf41134600689d6ba99e35dd22ba1f664f91e5c"
   integrity sha512-7PqvmsdQ7HIyxPUMYbd9Uq//VoMdniEOLAOSvIhb/ExtbAt/1INSjUF+RiMWOMCWLTCNvNPRvTz7xy7qwWureg==


### PR DESCRIPTION
## Description

The `Header.HEIGHT` in `react-navigation` is deprecated. Remove it and rather calculate different header height by recognizing `iphoneX` header defined as `isIPhoneXSize()` in `Styles.ts` util.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] Run `yarn lint`
- [x] I am willing to follow-up on review comments in a timely manner.
