### PR TITLE
Enhance screen transition and more refactoring

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { ApolloProvider, useQuery } from '@apollo/react-hooks';
 import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
-import { AuthUserProvider, useAuthUserContext } from './providers/AuthUserProvider';
+import { AuthProvider, useAuthContext } from './providers/AuthProvider';
 import React, { useEffect, useState } from 'react';
 import { ThemeProvider, ThemeType } from '@dooboo-ui/native-theme';
 import { dark, light } from './theme';
@@ -29,13 +29,13 @@ function App(): React.ReactElement {
   const colorScheme = useColorScheme();
 
   const [ready, setReady] = useState(false);
-  const { setAuthUser } = useAuthUserContext();
+  const { setUser } = useAuthContext();
 
   const { loading, data } = useQuery<{ me: User}, {}>(QUERY_ME);
 
   useEffect(() => {
     if (data && data.me) {
-      setAuthUser(data.me);
+      setUser(data.me);
     }
   }, [loading]);
 
@@ -64,11 +64,11 @@ function App(): React.ReactElement {
 function ProviderWrapper(): React.ReactElement {
   return (
     <AppearanceProvider>
-      <AuthUserProvider>
+      <AuthProvider>
         <ApolloProvider client={client}>
           <App />
         </ApolloProvider>
-      </AuthUserProvider>
+      </AuthProvider>
     </AppearanceProvider>
   );
 }

--- a/src/components/navigation/MainStackNavigator.tsx
+++ b/src/components/navigation/MainStackNavigator.tsx
@@ -17,6 +17,7 @@ import SearchUser from '../screen/SearchUser';
 import Setting from '../screen/Setting';
 import StatusBar from '../shared/StatusBar';
 import { getString } from '../../../STRINGS';
+import useAppState from '../../hooks/useAppState';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
 export type MainStackParamList = {
@@ -61,6 +62,9 @@ function getSimpleHeader(title: string, theme: DefaultTheme): StackNavigationOpt
 
 function MainStackNavigator(): ReactElement {
   const { theme } = useThemeContext();
+  const currentAppState = useAppState();
+  console.log('currentAppState', currentAppState);
+
   return (
     <Stack.Navigator
       initialRouteName="MainTab"

--- a/src/components/navigation/RootStackNavigator.tsx
+++ b/src/components/navigation/RootStackNavigator.tsx
@@ -4,9 +4,10 @@ import AuthStack from './AuthStackNavigator';
 import MainStack from './MainStackNavigator';
 import { NavigationNativeContainer } from '@react-navigation/native';
 import NotFound from '../screen/NotFound';
+import { Platform } from 'react-native';
 import React from 'react';
 import WebView from '../screen/WebView';
-import { useAuthUserContext } from '../../providers/AuthUserProvider';
+import { useAuthContext } from '../../providers/AuthProvider';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
 export type RootStackParamList = {
@@ -27,7 +28,7 @@ const Stack = createStackNavigator<RootStackParamList>();
 
 function RootNavigator(): React.ReactElement {
   const { theme } = useThemeContext();
-  const { state: { user } } = useAuthUserContext();
+  const { state: { user } } = useAuthContext();
 
   return (
     <NavigationNativeContainer>
@@ -43,8 +44,26 @@ function RootNavigator(): React.ReactElement {
       >
         {
           !user
-            ? <Stack.Screen name="AuthStack" component={AuthStack} />
-            : <Stack.Screen name="MainStack" component={MainStack} />
+            ? <Stack.Screen
+              name="AuthStack"
+              component={AuthStack}
+              options={{
+                gestureDirection: Platform.select({
+                  ios: !user ? 'horizontal-inverted' : 'horizontal',
+                  default: !user ? 'vertical-inverted' : 'vertical',
+                }),
+              }}
+            />
+            : <Stack.Screen
+              name="MainStack"
+              component={MainStack}
+              options={{
+                gestureDirection: Platform.select({
+                  ios: !user ? 'horizontal-inverted' : 'horizontal',
+                  default: !user ? 'vertical-inverted' : 'vertical',
+                }),
+              }}
+            />
         }
         <Stack.Screen name="WebView" component={WebView}
           options={{

--- a/src/components/navigation/__tests__/__snapshots__/RootStackNavigator.test.tsx.snap
+++ b/src/components/navigation/__tests__/__snapshots__/RootStackNavigator.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`[Stack] navigator should renders without crashing 1`] = `
                   "flex": 1,
                   "transform": Array [
                     Object {
-                      "translateX": 0,
+                      "translateX": -0,
                     },
                     Object {
                       "translateX": 0,
@@ -121,18 +121,18 @@ exports[`[Stack] navigator should renders without crashing 1`] = `
                 style={
                   Object {
                     "backgroundColor": "#fff",
-                    "bottom": 0,
+                    "height": 3,
                     "left": 0,
                     "position": "absolute",
+                    "right": 0,
                     "shadowColor": "#000",
                     "shadowOffset": Object {
-                      "height": 1,
-                      "width": -1,
+                      "height": -1,
+                      "width": 1,
                     },
                     "shadowOpacity": 0.3,
                     "shadowRadius": 5,
                     "top": 0,
-                    "width": 3,
                   }
                 }
               />

--- a/src/components/screen/ProfileUpdate.tsx
+++ b/src/components/screen/ProfileUpdate.tsx
@@ -9,7 +9,7 @@ import { SvgNoProfile } from '../../utils/Icons';
 import { getString } from '../../../STRINGS';
 import styled from 'styled-components/native';
 import { useActionSheet } from '@expo/react-native-action-sheet';
-import { useAuthUserContext } from '../../providers/AuthUserProvider';
+import { useAuthContext } from '../../providers/AuthProvider';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
 const BUTTON_INDEX_LAUNCH_CAMERA = 0;
@@ -62,7 +62,7 @@ function Screen(props: Props): React.ReactElement {
   const [statusMessage, setstatusMessage] = useState('');
   const { showActionSheetWithOptions } = useActionSheet();
   const [profilePath, setProfilePath] = useState('');
-  const { setAuthUser } = useAuthUserContext();
+  const { setUser } = useAuthContext();
 
   useEffect(() => {
     if (isUpdating) {
@@ -81,7 +81,7 @@ function Screen(props: Props): React.ReactElement {
   const onLogout = (): void => {
     if (navigation) {
       AsyncStorage.removeItem('token');
-      setAuthUser(undefined);
+      setUser(undefined);
     }
   };
 

--- a/src/components/screen/Setting/index.tsx
+++ b/src/components/screen/Setting/index.tsx
@@ -14,7 +14,7 @@ import { DefaultTheme } from 'styled-components/native';
 import { FontAwesome } from '@expo/vector-icons';
 import { MainStackNavigationProps } from '../../navigation/MainStackNavigator';
 import { getString } from '../../../../STRINGS';
-import { useAuthUserContext } from '../../../providers/AuthUserProvider';
+import { useAuthContext } from '../../../providers/AuthProvider';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
 interface SettingsOption {
@@ -44,7 +44,7 @@ export interface Props {
 function SettingScreen(props: Props): React.ReactElement {
   const { theme } = useThemeContext();
   const { navigation } = props;
-  const { state: { user } } = useAuthUserContext();
+  const { state: { user } } = useAuthContext();
 
   let signInInfoOption: SettingsOption;
 

--- a/src/components/screen/SignIn.tsx
+++ b/src/components/screen/SignIn.tsx
@@ -21,7 +21,7 @@ import { MUTATION_SIGN_IN } from '../../graphql/mutations';
 import StatusBar from '../shared/StatusBar';
 import { getString } from '../../../STRINGS';
 import styled from 'styled-components/native';
-import { useAuthUserContext } from '../../providers/AuthUserProvider';
+import { useAuthContext } from '../../providers/AuthProvider';
 import { useMutation } from '@apollo/react-hooks';
 import { validateEmail } from '../../utils/common';
 
@@ -96,7 +96,7 @@ const StyledAgreementLinedText = styled.Text`
 
 function SignIn(props: Props): ReactElement {
   const { navigation } = props;
-  const { setAuthUser } = useAuthUserContext();
+  const { setUser } = useAuthContext();
   const [isLoggingIn, setIsLoggingIn] = useState<boolean>(false);
   const [signingInFacebook, setSigningInFacebook] = useState<boolean>(false);
   const [signingInGoogle, setSigningInGoogle] = useState<boolean>(false);
@@ -134,8 +134,10 @@ function SignIn(props: Props): ReactElement {
 
     try {
       const { data } = await signInEmail({ variables });
-      AsyncStorage.setItem('token', data?.signInEmail.token || '');
-      setAuthUser(data?.signInEmail.user);
+      if (data && data.signInEmail) {
+        AsyncStorage.setItem('token', data.signInEmail.token);
+        setUser(data.signInEmail.user);
+      }
     } catch (err) {
       Alert.alert(getString('ERROR'), err.message);
     } finally {

--- a/src/components/screen/SignUp.tsx
+++ b/src/components/screen/SignUp.tsx
@@ -9,7 +9,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import StatusBar from '../shared/StatusBar';
 import { getString } from '../../../STRINGS';
 import styled from 'styled-components/native';
-import { useAuthUserContext } from '../../providers/AuthUserProvider';
+import { useAuthContext } from '../../providers/AuthProvider';
 import { useMutation } from '@apollo/react-hooks';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
@@ -50,7 +50,7 @@ function Page(): ReactElement {
   const [errorName, setErrorName] = useState<string>('');
   const [signingUp, setSigningUp] = useState<boolean>(false);
 
-  const { setAuthUser } = useAuthUserContext();
+  const { setUser } = useAuthContext();
   const { theme } = useThemeContext();
   const [signUp] = useMutation<{ signUp: AuthPayload }, MutationSignUpInput>(MUTATION_SIGN_UP);
 
@@ -84,7 +84,7 @@ function Page(): ReactElement {
     try {
       const { data } = await signUp({ variables });
       AsyncStorage.setItem('token', data?.signUp.token || '');
-      setAuthUser(data?.signUp.user);
+      setUser(data?.signUp.user);
     } catch (err) {
       Alert.alert(getString('ERROR'), err.message);
     } finally {

--- a/src/components/screen/__tests__/ProfileUpdate.test.tsx
+++ b/src/components/screen/__tests__/ProfileUpdate.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '@testing-library/react-native';
 import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
-import AuthUserContext from '../../../providers/AuthUserProvider';
+import AuthContext from '../../../providers/AuthProvider';
 import ProfileUpdate from '../ProfileUpdate';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
@@ -77,12 +77,12 @@ describe('interaction', () => {
 
   it('should fireEvent when logout button pressed', () => {
     jest
-      .spyOn(AuthUserContext, 'useAuthUserContext')
+      .spyOn(AuthContext, 'useAuthContext')
       .mockImplementation(() => ({
         state: {
           user: undefined,
         },
-        setAuthUser: jest.fn().mockReturnValue({
+        setUser: jest.fn().mockReturnValue({
           id: 'userId',
           email: 'email@email.com',
           nickname: 'nickname',

--- a/src/hooks/useAppState.tsx
+++ b/src/hooks/useAppState.tsx
@@ -1,0 +1,21 @@
+import { AppState, AppStateStatus } from 'react-native';
+import { useEffect, useState } from 'react';
+
+export default function useAppState(): AppStateStatus {
+  const currentState = AppState.currentState;
+  const [appState, setAppState] = useState(currentState);
+
+  function onChange(newState: AppStateStatus): void {
+    setAppState(newState);
+  }
+
+  useEffect(() => {
+    AppState.addEventListener('change', onChange);
+
+    return (): void => {
+      AppState.removeEventListener('change', onChange);
+    };
+  });
+
+  return appState;
+}

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -5,12 +5,12 @@ import createCtx from '../utils/createCtx';
 
 interface Context {
   state: State;
-  setAuthUser(user: User | undefined): void;
+  setUser(user: User | undefined): void;
 }
 const [useCtx, Provider] = createCtx<Context>();
 
 export enum ActionType {
-  SetAuthUser = 'set-auth-user',
+  SetUser = 'set-user',
 }
 
 export interface State {
@@ -18,7 +18,7 @@ export interface State {
 }
 
 type Action =
-  | { type: ActionType.SetAuthUser; payload: State };
+  | { type: ActionType.SetUser; payload: State };
 
 interface Props {
   children?: React.ReactElement;
@@ -27,9 +27,9 @@ interface Props {
 
 type Reducer = (state: State, action: Action) => State;
 
-const setAuthUser = (dispatch: React.Dispatch<Action>) => (authUser: User): void => {
+const setUser = (dispatch: React.Dispatch<Action>) => (authUser: User): void => {
   dispatch({
-    type: ActionType.SetAuthUser,
+    type: ActionType.SetUser,
     payload: { user: authUser },
   });
 };
@@ -39,7 +39,7 @@ const initialState: State = {};
 const reducer: Reducer = (state = initialState, action) => {
   const { type, payload } = action;
   switch (type) {
-    case ActionType.SetAuthUser:
+    case ActionType.SetUser:
       return {
         user: payload.user,
       };
@@ -48,21 +48,21 @@ const reducer: Reducer = (state = initialState, action) => {
   }
 };
 
-function AuthUserProvider(props: Props): React.ReactElement {
+function AuthProvider(props: Props): React.ReactElement {
   const { children, initialAuthUser } = props;
   const [state, dispatch] = useReducer<Reducer>(reducer, { user: initialAuthUser });
 
   const actions = {
-    setAuthUser: setAuthUser(dispatch),
+    setUser: setUser(dispatch),
   };
 
   return <Provider value={{ state, ...actions }}>{children}</Provider>;
 }
 
-const AuthUserContext = {
-  useAuthUserContext: useCtx,
-  AuthUserProvider,
+const AuthContext = {
+  useAuthContext: useCtx,
+  AuthProvider,
 };
 
-export { useCtx as useAuthUserContext, AuthUserProvider };
-export default AuthUserContext;
+export { useCtx as useAuthContext, AuthProvider };
+export default AuthContext;

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -3,7 +3,7 @@ import { dark, light } from '../theme';
 
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { ApolloProvider } from '@apollo/react-hooks';
-import { AuthUserProvider } from './AuthUserProvider';
+import { AuthProvider } from './AuthProvider';
 import { FriendProvider } from './FriendProvider';
 import { ProfileModalProvider } from './ProfileModalProvider';
 import React from 'react';
@@ -29,11 +29,11 @@ export const AllProviders = ({
     >
       <ApolloProvider client={testClient}>
         <FriendProvider>
-          <AuthUserProvider initialAuthUser={initialAuthUser}>
+          <AuthProvider initialAuthUser={initialAuthUser}>
             <ProfileModalProvider>
               {children}
             </ProfileModalProvider>
-          </AuthUserProvider>
+          </AuthProvider>
         </FriendProvider>
       </ApolloProvider>
     </ThemeProvider>
@@ -45,9 +45,9 @@ export default ({ initialThemeType, children }: Props): React.ReactElement => {
     <ThemeProvider
       initialThemeType={initialThemeType}
     >
-      <AuthUserProvider>
+      <AuthProvider>
         <ActionSheetProvider>{children}</ActionSheetProvider>
-      </AuthUserProvider>
+      </AuthProvider>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## Description

* Screen navigate from right when signin and reverse when signout
* Shorten AuthUserProvider to AuthProvider
* Add useAppState hook to handle onResume and onPause lifecycle

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
