### PR TITLE
[WIP][Enhance] Enable to reset relay environment as user logging out

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,5 +3,4 @@ module.exports = {
   arrowParens: 'always',
   singleQuote: true,
   jsxSingleQuote: false,
-  printWidth: 120,
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import * as Device from 'expo-device';
 
+import type { AppUserQuery, AppUserQueryResponse } from './__generated__/AppUserQuery.graphql';
 import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
 import { AuthProvider, useAuthContext } from './providers/AuthProvider';
 import { DeviceProvider, useDeviceContext } from './providers/DeviceProvider';
@@ -20,7 +21,6 @@ import { ThemeProvider, ThemeType } from '@dooboo-ui/native-theme';
 import { dark, light } from './theme';
 
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
-import type { AppUserQuery } from './__generated__/AppUserQuery.graphql';
 import AsyncStorage from '@react-native-community/async-storage';
 import Config from 'react-native-config';
 import RootNavigator from './components/navigation/RootStackNavigator';
@@ -69,10 +69,15 @@ function AppWithTheme(): ReactElement {
     setDeviceType(deviceType);
   };
 
+  const initUser = async (me: AppUserQueryResponse['me']): Promise<void> => {
+    if (!me) return;
+    await initializeEThree(me.id);
+    setUser(me);
+  };
+
   useEffect(() => {
     if (data.me) {
-      initializeEThree(data.me.id);
-      setUser(data.me);
+      initUser(data.me);
       return;
     }
 

--- a/src/components/navigation/MainStackNavigator.tsx
+++ b/src/components/navigation/MainStackNavigator.tsx
@@ -29,6 +29,7 @@ import Settings from '../screen/Settings';
 import StatusBar from '../shared/StatusBar';
 import { getString } from '../../../STRINGS';
 import useAppState from '../../hooks/useAppState';
+import { useAuthContext } from '../../providers/AuthProvider';
 import { useThemeContext } from '@dooboo-ui/native-theme';
 
 export type MainStackParamList = {
@@ -50,8 +51,8 @@ type NavigationProps<
 export type MainStackNavigationProps<
   T extends keyof MainStackParamList = 'default'
 > = CompositeNavigationProp<
-NavigationProps<T>,
-RootStackNavigationProps<'MainStack'>
+  NavigationProps<T>,
+  RootStackNavigationProps<'MainStack'>
 >;
 
 const Stack = createStackNavigator<MainStackParamList>();
@@ -195,6 +196,13 @@ function RootNavigator(): ReactElement {
 }
 
 export default function RootNavigatorWrapper(): ReactElement {
+  const { resetRelay } = useAuthContext();
+  useEffect(() => {
+    return (): void => {
+      // console.log('Unmount MainStack');
+      resetRelay();
+    };
+  }, []);
   return (
     <ProfileModalProvider>
       <RootNavigator />

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,4 +1,7 @@
 import React, { useReducer } from 'react';
+import RelayEnvironment, {
+  RelayEnvironmentProps,
+} from '../relay/RelayEnvironment';
 
 import { User } from '../types/graphql';
 import createCtx from '../utils/createCtx';
@@ -6,19 +9,22 @@ import createCtx from '../utils/createCtx';
 interface Context {
   state: State;
   setUser(user: User | undefined): void;
+  resetRelay(): void;
 }
 const [useCtx, Provider] = createCtx<Context>();
 
 export enum ActionType {
   SetUser = 'set-user',
+  ResetRelay = 'reset-relay',
 }
 
 export interface State {
-  user?: User;
+  user: User | undefined | null;
+  relay: RelayEnvironmentProps;
 }
-
-type Action =
-  | { type: ActionType.SetUser; payload: State };
+type SetUserAction = { type: ActionType.SetUser; payload: { user: User } };
+type ResetRelayAction = { type: ActionType.ResetRelay };
+type Action = SetUserAction | ResetRelayAction;
 
 interface Props {
   children?: React.ReactElement;
@@ -27,36 +33,52 @@ interface Props {
 
 type Reducer = (state: State, action: Action) => State;
 
-const setUser = (dispatch: React.Dispatch<Action>) => (authUser: User): void => {
+const setUser = (dispatch: React.Dispatch<SetUserAction>) => (
+  authUser: User,
+): void => {
   dispatch({
     type: ActionType.SetUser,
     payload: { user: authUser },
   });
 };
+const resetRelay = (dispatch: React.Dispatch<ResetRelayAction>) => (): void => {
+  dispatch({
+    type: ActionType.ResetRelay,
+  });
+};
 
-const initialState: State = {};
+const initialState: State = {
+  user: undefined,
+  relay: RelayEnvironment.getEnvironment(),
+};
 
 const reducer: Reducer = (state = initialState, action) => {
-  const { type, payload } = action;
-  switch (type) {
+  switch (action.type) {
     case ActionType.SetUser:
       return {
-        user: payload.user,
+        ...state,
+        user: action.payload.user,
       };
+    case ActionType.ResetRelay:
+      return { ...state, relay: RelayEnvironment.resetEnvironment() };
     default:
       return state;
   }
 };
 
 function AuthProvider(props: Props): React.ReactElement {
-  const { children, initialAuthUser } = props;
-  const [state, dispatch] = useReducer<Reducer>(reducer, { user: initialAuthUser });
+  const initialAuthState = {
+    user: props.initialAuthUser,
+    relay: RelayEnvironment.getEnvironment(),
+  };
+  const [state, dispatch] = useReducer<Reducer>(reducer, initialAuthState);
 
   const actions = {
     setUser: setUser(dispatch),
+    resetRelay: resetRelay(dispatch),
   };
 
-  return <Provider value={{ state, ...actions }}>{children}</Provider>;
+  return <Provider value={{ state, ...actions }}>{props.children}</Provider>;
 }
 
 const AuthContext = {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -49,7 +49,7 @@ const resetRelay = (dispatch: React.Dispatch<ResetRelayAction>) => (): void => {
 
 const initialState: State = {
   user: undefined,
-  relay: RelayEnvironment.getEnvironment(),
+  relay: RelayEnvironment.environment,
 };
 
 const reducer: Reducer = (state = initialState, action) => {
@@ -69,7 +69,7 @@ const reducer: Reducer = (state = initialState, action) => {
 function AuthProvider(props: Props): React.ReactElement {
   const initialAuthState = {
     user: props.initialAuthUser,
-    relay: RelayEnvironment.getEnvironment(),
+    relay: RelayEnvironment.environment,
   };
   const [state, dispatch] = useReducer<Reducer>(reducer, initialAuthState);
 

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -1,22 +1,37 @@
 import * as Device from 'expo-device';
 
+import { AuthProvider, useAuthContext } from './AuthProvider';
+import React, { ReactElement } from 'react';
 import { ThemeProvider, ThemeType } from '@dooboo-ui/native-theme';
 import { dark, light } from '../theme';
 
-import { AuthProvider } from './AuthProvider';
 import { DeviceProvider } from './DeviceProvider';
 import { ProfileModalProvider } from './ProfileModalProvider';
-import React from 'react';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import { User } from '../types/graphql';
-import environment from '../relay/RelayEnvironment';
 
-interface Props {
+interface AllProvidersProps {
   initialDeviceType?: Device.DeviceType;
   initialThemeType?: ThemeType;
   initialAuthUser?: User;
   children?: React.ReactElement;
 }
+interface RelayProvidersProps {
+  children?: React.ReactElement;
+}
+
+const RelayProviderWrapper = ({
+  children,
+}: RelayProvidersProps): ReactElement => {
+  const {
+    state: { relay },
+  } = useAuthContext();
+  return (
+    <RelayEnvironmentProvider environment={relay}>
+      <ProfileModalProvider>{children}</ProfileModalProvider>
+    </RelayEnvironmentProvider>
+  );
+};
 
 // hyochan => for testing
 export const AllProviders = ({
@@ -24,22 +39,16 @@ export const AllProviders = ({
   initialAuthUser,
   initialDeviceType,
   children,
-}: Props): React.ReactElement => {
+}: AllProvidersProps): React.ReactElement => {
   return (
-    <DeviceProvider
-      initialDeviceType={initialDeviceType}
-    >
+    <DeviceProvider initialDeviceType={initialDeviceType}>
       <ThemeProvider
         initialThemeType={initialThemeType}
         customTheme={{ light, dark }}
       >
-        <RelayEnvironmentProvider environment={environment}>
-          <AuthProvider initialAuthUser={initialAuthUser}>
-            <ProfileModalProvider>
-              {children}
-            </ProfileModalProvider>
-          </AuthProvider>
-        </RelayEnvironmentProvider>
+        <AuthProvider initialAuthUser={initialAuthUser}>
+          <RelayProviderWrapper>{children}</RelayProviderWrapper>
+        </AuthProvider>
       </ThemeProvider>
     </DeviceProvider>
   );

--- a/src/relay/RelayEnvironment.ts
+++ b/src/relay/RelayEnvironment.ts
@@ -12,6 +12,8 @@ import {
 import AsyncStorage from '@react-native-community/async-storage';
 import fetchGraphQL from './fetch';
 
+const __DEV__ = process.env.NODE_ENV === 'development';
+
 function fetchFunction(
   request: RequestParameters,
   variables: Variables,
@@ -23,9 +25,29 @@ function fetchFunction(
   });
 }
 
-export const relayEnvConfig = {
-  network: Network.create(fetchFunction),
-  store: new Store(new RecordSource()),
-};
+export type RelayEnvironmentProps = Environment;
 
-export default new Environment(relayEnvConfig);
+class RelayEnvironment {
+  config = {
+    network: Network.create(fetchFunction),
+    store: new Store(new RecordSource()),
+  };
+
+  environment: RelayEnvironmentProps = new Environment(this.config);
+
+  constructor() {
+    this.resetEnvironment();
+  }
+
+  getEnvironment(): RelayEnvironmentProps {
+    return this.environment;
+  }
+
+  resetEnvironment(): RelayEnvironmentProps {
+    if (__DEV__) console.log('relay env instance initialized');
+    this.environment = new Environment(this.config);
+    return this.environment;
+  }
+}
+
+export default new RelayEnvironment();

--- a/src/relay/RelayEnvironment.ts
+++ b/src/relay/RelayEnvironment.ts
@@ -14,7 +14,7 @@ import fetchGraphQL from './fetch';
 
 const __DEV__ = process.env.NODE_ENV === 'development';
 
-function fetchFunction(
+async function fetchFunction(
   request: RequestParameters,
   variables: Variables,
   cacheConfig: CacheConfig,

--- a/src/utils/virgil.ts
+++ b/src/utils/virgil.ts
@@ -166,6 +166,7 @@ export const initializeEThree = async (userId: string): Promise<void> => {
     AsyncStorage.removeItem('password');
   } catch (err) {
     console.log('Ethree register error', err);
+    cleanupEThree();
   }
 };
 


### PR DESCRIPTION
## Description
There's only one relay environment instance for whole app.
It may occurs some of problems when new user login after old user logging out.
So, I tried to refresh the stale env instance to the new one.
It can be managed by custom class, `src/relay/RelayEnvironment.ts`

## Related Issues

#134 
#137 

## Tests

I added the following tests:

28 tests is fail following the updates.
I will apply the relevant updates in the test code.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
